### PR TITLE
Raise error if version not found

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -30,9 +30,11 @@ install_ruby() {
     opts="$opts $RUBY_BUILD_OPTS"
   fi
 
+  set +e
   matching_version=$(is_version_valid "$version")
+  set -e
 
-  if [[ -n "$matching_version" ]]; then
+  if [[ -z "$matching_version" ]]; then
     errorexit "Version not found"
   fi
 


### PR DESCRIPTION
Disables the `-e` flag in the bash script which prevents the `grep` command on the version check from raising the errorexit.